### PR TITLE
Add config option to override Express' default request size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- feat: add `limit` option to override Express' default request body size limit
+
 ## [0.4.0] - 2025-12-06
 * minor: use live config values to better support VSCode extension.
 * patch: make `debug` initialize lazily to pick up env vars in runtime.

--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Configures global cache.
   * `basePath: string` - Path to a directory to store persistent values. Default is `.global-cache`.
   * `ignoreTTL: boolean` - Forces all values to be non-persistent, usefull for CI (where cross run caching is redundant). Default is `false`.
   * `disabled: boolean` - Disables global cache. All values will be computed each time. Default is `false`.
+  * `limit: number | string` - Set the maximum allowed size in bytes of each cached value. [Default is from Express](https://expressjs.com/en/resources/middleware/body-parser.html#bodyparserjsonoptions): `'100kb'` 
 
 **Returns**: `void`
 

--- a/packages/core/src/client/config.ts
+++ b/packages/core/src/client/config.ts
@@ -14,6 +14,8 @@ export type GlobalCacheConfig = {
   disabled?: boolean;
   /* External server url */
   serverUrl?: string;
+  /* Change the size limit for cache values (default is Express' default json limit, currently '100kb') */
+  limit?: number | string;
 };
 
 type GlobalConfigInternal = GlobalCacheConfig & {
@@ -85,6 +87,10 @@ export class GlobalConfig {
 
   get disabled() {
     return Boolean(this.config.disabled);
+  }
+
+  get limit() {
+    return this.config.limit;
   }
 }
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -17,6 +17,7 @@ import { router as routeGetStaleList } from './routes/get-stale-list';
 import { router as routeClearTestRun } from './routes/clear';
 import { errorHandler } from './error';
 import { GlobalCacheServerConfig, resolveConfig, setConfig } from './config';
+import { globalConfig } from '../client/config';
 import { startExpressServer, stopExpressServer } from './utils/express';
 
 export class GlobalCacheServer {
@@ -24,7 +25,7 @@ export class GlobalCacheServer {
   private server: http.Server | null = null;
 
   constructor() {
-    this.app.use(express.json());
+    this.app.use(express.json({ limit: globalConfig.limit }));
     this.app.use('/', routeRoot);
     this.app.use('/', routeGet);
     this.app.use('/', routeSet);


### PR DESCRIPTION
Hello! I've been using your package to parallelise some test scripts. One of them creates ~300kb of data that needs caching, which resulted in `Error: request entity too large`, which I found was coming from Express, [which has a default limit of 100kb](https://expressjs.com/en/resources/middleware/body-parser.html).

This change lets you increase that limit:

```ts
globalCache.config({
  limit: '10mb',
});

export default globalCache.wrap(config);
```

With that, caching works in my test.

`limit` isn't a very helpful name imo, but I couldn't think of something succinct and enlightening so I just copied what it's called in `express`.

I published my fork [here](https://github.com/bdcarr/global-cache/pkgs/npm/global-cache-playwright), just so my team can use it until this PR is accepted, so if you want to try it out, there it is. Immediately after doing that I learned about [patch-package](https://www.npmjs.com/package/patch-package). Oh well.